### PR TITLE
build: fix version declaration

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -6,5 +6,5 @@
                      "racket-doc"))
 (define scribblings '(("scribblings/zubat.scrbl" ())))
 (define pkg-desc "走rust ffi的html5解释器")
-(define version "0.6.0")
+(define version "0.6")
 (define pkg-authors '(XG.Ley))


### PR DESCRIPTION
I've recently [changed] `raco setup` to report invalid package versions (according to this [spec]) and I'm slowly going through all published packages that have version issues to fix them in anticipation of that change being released in 8.9.

[changed]: https://github.com/racket/racket/pull/4588
[spec]: https://docs.racket-lang.org/version/index.html#%28def._%28%28lib._version%2Futils..rkt%29._valid-version~3f%29%29